### PR TITLE
Update utils and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-ls/lua-language-server
+ls/*
 plugin/

--- a/lua/vapour-user-config/README.md
+++ b/lua/vapour-user-config/README.md
@@ -4,15 +4,13 @@ Just create an `init.lua` file here and update that.
 
 ## Plugins
 
-To install plugins, set the `Vapour.user.plugins` property.
+To install plugins, set the `Vapour.plugins.user` property.
 
 For example, to install FTerm::
 
 ```
-Vapour.user = {
-  plugins = {
+Vapour.plugins.user = {
     {"numtostr/FTerm.nvim", config = function() require("FTerm").setup() end}
-  }
 }
 ```
 

--- a/lua/vapour-user-config/init.lua.example
+++ b/lua/vapour-user-config/init.lua.example
@@ -1,0 +1,23 @@
+Vapour.plugins.packer = {
+  init = {
+    display = {
+      open_fn = function()
+        return Vapour.utils.plugins.require_if_installed('packer.util').float { border = "single" }
+      end
+    },
+  },
+}
+
+Vapour.plugins.user = {
+  {"rcarriga/nvim-dap-ui", requires = {"mfussenegger/nvim-dap"}},
+}
+
+-- These assume either vapour-user-config/*/init.lua or vapour-user-config/*.lua
+Vapour.utils.plugins.require_if_installed('vapour-user-config.dap')
+Vapour.utils.plugins.require_if_installed('vapour-user-config.autopairs')
+
+-- To magic-load or add a missing package
+Vapour.utils.plugins.require_if_installed("folke/which-key.nvim")
+
+-- To magic-load or add a missing package w/ packer config
+Vapour.utils.plugins.require_if_installed("folke/which-key.nvim", { config = function() end})

--- a/lua/vapour-utils/init.lua
+++ b/lua/vapour-utils/init.lua
@@ -9,10 +9,17 @@ Vapour.utils = {
   plugins = {
     -- Allows us to require packages in vapour-user-config
     -- without throwing exceptions if the package don't exist
-    require_if_installed = function(pkg)
-      local ok, package = pcall(require, pkg)
+    -- Optionally you can run this like some/package to add it
+    -- to the Vapour.packages.user table for installation.
+    require_if_installed = function(pkg, conf)
+      local user, repo = string.match(pkg, "(.*)/(.*)")
+      local pkg_config = conf or {}
 
-      if ok then return package else return nil end
+      if not repo then repo = pkg end
+
+      local ok, package = pcall(require, repo)
+
+      if ok then return package else table.insert(Vapour.plugins.user, {pkg, conf}) return nil end
     end,
   },
 }


### PR DESCRIPTION
Noticed a typo in the README and I improved `require_if_installed` to either load or insert the package into the user plugins table, depending on if it exists or not.

If an example file is wanted for the init, or if I can somehow edit the wiki to provide an example (I don't know how that works on GitHub) I'd be happy to provide.

To finish up #5 I'll make another branch to move a lot of configuration over to `Vapour.plugins` in the `lua/options/init.lua` and update what needs to be.